### PR TITLE
Add support for runner online status `null`

### DIFF
--- a/src/GitLabKit.Runner.Core/Models/Runner.cs
+++ b/src/GitLabKit.Runner.Core/Models/Runner.cs
@@ -22,7 +22,7 @@ public class Runner
     public bool Active { get; set; }
 
     [JsonProperty("online")]
-    public bool Online { get; set; }
+    public bool? Online { get; set; }
     
     [JsonProperty("contacted_at")]
     public DateTime ContactedAt { get; set; }

--- a/src/GitLabKit.Runner.Mock/Generator.cs
+++ b/src/GitLabKit.Runner.Mock/Generator.cs
@@ -18,7 +18,7 @@ public static class Generator
             Description = $"test-runner-{runnerId}",
             IpAddress = $"10.1.1.{runnerId % 255}",
             Active = runnerId % 7 != 0,
-            Online = runnerId % 15 != 0,
+            Online = runnerId % 15 != 0 ? true : runnerId % 16 != 0 ? null : false,
             ContactedAt = DateTime.Now,
             TagList = new List<string>{runnerId < 2010 ? "windows" : "linux", $"tag-{runnerId % 3 + 1}"}
         };

--- a/src/GitLabKit.Runner.Mock/Generator.cs
+++ b/src/GitLabKit.Runner.Mock/Generator.cs
@@ -18,7 +18,7 @@ public static class Generator
             Description = $"test-runner-{runnerId}",
             IpAddress = $"10.1.1.{runnerId % 255}",
             Active = runnerId % 7 != 0,
-            Online = runnerId % 15 != 0 ? true : runnerId % 16 != 0 ? null : false,
+            Online = runnerId % 15 != 0,
             ContactedAt = DateTime.Now,
             TagList = new List<string>{runnerId < 2010 ? "windows" : "linux", $"tag-{runnerId % 3 + 1}"}
         };

--- a/src/clientside/src/api-client/generated/api.ts
+++ b/src/clientside/src/api-client/generated/api.ts
@@ -245,7 +245,7 @@ export interface Runner {
      * @type {boolean}
      * @memberof Runner
      */
-    'online': boolean;
+    'online'?: boolean | null;
     /**
      * 
      * @type {string}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5965883/167580402-e8ca4071-b581-4936-ad16-dc07d161f9b4.png)

note: `online: null` will be treated as `offline`